### PR TITLE
fixed employees js url

### DIFF
--- a/src/apps.json.prod
+++ b/src/apps.json.prod
@@ -2,7 +2,7 @@
     {
         "short_name": "employees",
         "name": "Ansattliste",
-        "script": "https://storage.googleapis.com/blank-intranet-test/employees/js/app.bundle.js",
+        "script": "https://storage.googleapis.com/blank-intranet/employees/js/app.bundle.js",
         "config": {
             "apiUri": "https://api.floq.no"
         }


### PR DESCRIPTION
seems the url for the employees app.bundle.js was pointing at the test bucket. not anymore